### PR TITLE
Update 3.2 Functions (函数).ipynb

### DIFF
--- a/Chapter-03/3.2 Functions (函数).ipynb
+++ b/Chapter-03/3.2 Functions (函数).ipynb
@@ -888,7 +888,8 @@
     "import itertools \n",
     "\n",
     "first_letter = lambda x: x[0]\n",
-    "names = ['Alan', 'Adam', 'Wes', 'Will', 'Albert', 'Steven']"
+    "names = ['Alan', 'Adam', 'Wes', 'Will', 'Albert', 'Steven']\n",
+    "names = sorted(names,key=first_letter)"
    ]
   },
   {
@@ -902,10 +903,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "A ['Alan', 'Adam']\n",
-      "W ['Wes', 'Will']\n",
-      "A ['Albert']\n",
-      "S ['Steven']\n"
+      "A ['Alan', 'Adam', 'Albert']\n",
+      "S ['Steven']\n",
+      "W ['Wes', 'Will']\n"
      ]
     }
    ],


### PR DESCRIPTION
update 'itertools.groupby' codes

感谢分享，下面是我的理解，有什么问题还望指正。^_^
```
itertools.groupby(iterable[, key])
```
根据[文档](https://docs.python.org/2/library/itertools.html#itertools.groupby)里面的这段解释
>The operation of groupby() is similar to the uniq filter in Unix. It generates a break or new group every time the value of the key function changes (which is why it is usually necessary to have sorted the data using the same key function). 

>可以发现，这里groupby的使用类似于Unix里面的uniq(uniq可检查文本文件中重复出现的行 --> 重复行是指连续出现的重复行)命令，key函数值的改变会中断或者生成新的组(这就是为什么使用相同key函数对数据排序的原因)，所以这里groupby 可以理解为把迭代器中相邻的重复元素挑出来放在一起([参考廖雪峰groupby](https://www.liaoxuefeng.com/wiki/0014316089557264a6b348958f449949df42a6d3a2e542c000/00143200162233153835cfdd1a541a18ddc15059e3ddeec000))

```
groups = []
uniquekeys = []
data = sorted(data, key=keyfunc)
for k, g in groupby(data, keyfunc):
    groups.append(list(g))      # Store group iterator as a list
    uniquekeys.append(k)
```